### PR TITLE
matching drush to travis

### DIFF
--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -18,7 +18,11 @@ export APACHE_CONFIG_FILE=/etc/apache2/sites-enabled/000-default.conf
 apt-get -y install php5-gd php5-dev php5-xsl php-soap php5-curl php5-imagick imagemagick lame libimage-exiftool-perl bibutils poppler-utils
 pecl install uploadprogress
 sed -i '/; extension_dir = "ext"/ a\ extension=uploadprogress.so' /etc/php5/apache2/php.ini
-apt-get -y install drush
+#Ensure same drush as travis
+wget http://alpha.library.yorku.ca/drush-6.3.tar.gz
+tar xf drush-6.3.tar.gz
+sudo mv drush-6.3 /opt/
+sudo ln -s /opt/drush-6.3/drush /usr/bin/drush
 a2enmod rewrite
 service apache2 reload
 cd /var/www


### PR DESCRIPTION
https://github.com/Islandora-Labs/islandora_vagrant_base_box/issues/8

Matching drush version with what is currently in travis for release. Travis would need to be updated and ensure no tests fail before we can move base box to drush 7. This should be considered for next release but it is out of scope of islandora_vagrant_base_box issue. We should always match community deployment guide and vagrant box drush version to what is currently in Travis.

To test bring up vagrant box based on pull and ensure drush version is 6.3.0 and that you can run drush commands as expected.