### PR TITLE
Issue 28

### DIFF
--- a/configs/log4j.xml
+++ b/configs/log4j.xml
@@ -39,6 +39,11 @@
     <appender-ref ref="FILEOUT"/>
   </logger>
 
+  <logger name="dk.defxws.fgssolrremote" additivity="false">
+    <level value="INFO" />
+    <appender-ref ref="FILEOUT"/>
+  </logger>
+
   <root>
     <level value="WARN" />
     <appender-ref ref="STDOUT"/>

--- a/configs/log4j.xml
+++ b/configs/log4j.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- $Id$ -->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+  <appender name="STDOUT" class="org.apache.log4j.ConsoleAppender">
+    <param name="File" value="/usr/local/fedora/server/logs/fedoragsearch.log"/>
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%p %d (%c{1}) %m%n"/>
+    </layout>
+  </appender>
+
+  <appender name="FILEOUT" class="org.apache.log4j.FileAppender">
+    <param name="File" value="/usr/local/fedora/server/logs/fedoragsearch.log"/>
+    <param name="append" value="true" />
+    <param name="threshold" value="debug" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%p %d (%c{1}) %m%n"/>
+    </layout>
+  </appender>
+
+  <logger name="dk.defxws.fedoragsearch" additivity="false">
+    <level value="INFO" />
+    <appender-ref ref="FILEOUT"/>
+  </logger>
+
+  <logger name="dk.defxws.fgszebra" additivity="false">
+    <level value="INFO" />
+    <appender-ref ref="FILEOUT"/>
+  </logger>
+  
+  <logger name="dk.defxws.fgslucene" additivity="false">
+    <level value="INFO" />
+    <appender-ref ref="FILEOUT"/>
+  </logger>
+
+  <logger name="dk.defxws.fgssolr" additivity="false">
+    <level value="INFO" />
+    <appender-ref ref="FILEOUT"/>
+  </logger>
+
+  <root>
+    <level value="WARN" />
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+</log4j:configuration>

--- a/configs/variables
+++ b/configs/variables
@@ -13,7 +13,7 @@ FEDORA_HOME="/usr/local/fedora"
 FFMPEG_VERSION=1.1.4
 
 FITS_HOME="/usr/local/fits"
-FITS_VERSION=1.1.0
+FITS_VERSION=1.1.1
 
 SOLR_HOME="/usr/local/fedora/solr"
 SOLR_VERSION=4.10.4

--- a/configs/variables
+++ b/configs/variables
@@ -13,9 +13,9 @@ FEDORA_HOME="/usr/local/fedora"
 FFMPEG_VERSION=1.1.4
 
 FITS_HOME="/usr/local/fits"
-FITS_VERSION=0.10.1
+FITS_VERSION=1.1.0
 
-SOLR_HOME="/usr/local/solr"
-SOLR_VERSION=4.2.0
+SOLR_HOME="/usr/local/fedora/solr"
+SOLR_VERSION=4.10.4
 
 DRUPAL_HOME="/var/www/drupal"

--- a/configs/variables
+++ b/configs/variables
@@ -15,7 +15,7 @@ FFMPEG_VERSION=1.1.4
 FITS_HOME="/usr/local/fits"
 FITS_VERSION=1.1.1
 
-SOLR_HOME="/usr/local/fedora/solr"
+SOLR_HOME="/usr/local/solr"
 SOLR_VERSION=4.10.4
 
 DRUPAL_HOME="/var/www/drupal"

--- a/scripts/gsearch.sh
+++ b/scripts/gsearch.sh
@@ -13,6 +13,7 @@ fi
 cd /tmp || exit
 git clone -b 4.10.x --recursive https://github.com/discoverygarden/basic-solr-config.git
 ln -s /var/lib/tomcat7 /usr/local/fedora/tomcat
+sed -i "s|/usr/local/fedora/solr|$SOLR_HOME|g" /tmp/basic-solr-config/index.properties
 
 # dgi_gsearch_extensions
 cd /tmp || exit
@@ -44,7 +45,7 @@ ant -f fgsconfig-basic.xml -Dlocal.FEDORA_HOME="$FEDORA_HOME" -DgsearchUser=fedo
 
 
 # Deploy dgi_gsearch_extensions
-cp -v /tmp/dgi_gsearch_extensions/target/gsearch_extensions-0.1.2-jar-with-dependencies.jar /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/lib
+cp -v /tmp/dgi_gsearch_extensions/target/gsearch_extensions-0.1.3-jar-with-dependencies.jar /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/lib
 
 # Solr & GSearch configurations
 cp -v /tmp/basic-solr-config/conf/* "$SOLR_HOME"/collection1/conf

--- a/scripts/gsearch.sh
+++ b/scripts/gsearch.sh
@@ -11,9 +11,8 @@ fi
 
 # Dependencies
 cd /tmp || exit
-git clone -b 4.x --recursive https://github.com/discoverygarden/basic-solr-config.git
-cd basic-solr-config/islandora_transforms || exit
-sed -i 's#/usr/local/fedora/tomcat#/var/lib/tomcat7#g' ./*xslt
+git clone -b 4.10.x --recursive https://github.com/discoverygarden/basic-solr-config.git
+ln -s /var/lib/tomcat7 /usr/local/fedora/tomcat
 
 # dgi_gsearch_extensions
 cd /tmp || exit
@@ -23,7 +22,7 @@ mvn -q package
 
 # Build GSearch
 cd /tmp || exit
-git clone https://github.com/fcrepo3/gsearch.git
+git clone https://github.com/discoverygarden/gsearch.git
 cd gsearch/FedoraGenericSearch || exit
 ant buildfromsource
 
@@ -38,18 +37,26 @@ service tomcat7 restart
 sleep 75
 
 # GSearch configurations
-cd /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes || exit
-wget -q http://alpha.library.yorku.ca/fgsconfigFinal.zip
-unzip fgsconfigFinal.zip
+cd /var/lib/tomcat7/webapps/fedoragsearch/FgsConfig || exit
+ant -f fgsconfig-basic.xml -Dlocal.FEDORA_HOME="$FEDORA_HOME" -DgsearchUser=fedoraAdmin -DgsearchPass=fedoraAdmin -DfinalConfigPath=/var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes -DlogFilePath="$FEDORA_HOME"/server/logs -DfedoraUser=fedoraAdmin -DfedoraPass=fedoraAdmin -DobjectStoreBase="$FEDORA_HOME"/data/objectStore -DindexDir="$SOLR_HOME"/collection1/data/index -DindexingDocXslt=foxmlToSolr -propertyfile fgsconfig-basic-for-islandora.properties
+
+
+
 
 # Deploy dgi_gsearch_extensions
-cp -v /tmp/dgi_gsearch_extensions/target/gsearch_extensions-0.1.1-jar-with-dependencies.jar /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/lib
+cp -v /tmp/dgi_gsearch_extensions/target/gsearch_extensions-0.1.2-jar-with-dependencies.jar /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/lib
 
 # Solr & GSearch configurations
-cp -v /tmp/basic-solr-config/conf/* /usr/local/solr/collection1/conf
-cp -Rv /tmp/basic-solr-config/islandora_transforms/* /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms
-chown -hR tomcat7:tomcat7 /usr/local/solr
+cp -v /tmp/basic-solr-config/conf/* "$SOLR_HOME"/collection1/conf
+cp -Rv /tmp/basic-solr-config/islandora_transforms /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms
+cp /tmp/basic-solr-config/foxmlToSolr.xslt /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/foxmlToSolr.xslt
+cp /tmp/basic-solr-config/index.properties /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/index.properties
+chown -hR tomcat7:tomcat7 "$SOLR_HOME"
 chown -hR tomcat7:tomcat7 /var/lib/tomcat7/webapps/fedoragsearch
+
+#Gsearch logging
+cp "$SHARED_DIR"/configs/log4j.xml /usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes
+
 
 # Restart Tomcat
 chown tomcat7:tomcat7 /var/lib/tomcat7/webapps/fedoragsearch.war

--- a/scripts/solr.sh
+++ b/scripts/solr.sh
@@ -24,11 +24,15 @@ if [ ! -d "$SOLR_HOME" ]; then
 fi
 cd /tmp/solr-"$SOLR_VERSION"/example/solr || exit
 mv -v ./* "$SOLR_HOME"
+
+
 chown -hR tomcat7:tomcat7 "$SOLR_HOME"
 
 # Deploy Solr
 cp -v "/tmp/solr-$SOLR_VERSION/dist/solr-$SOLR_VERSION.war" "/var/lib/tomcat7/webapps/solr.war"
-chown tomcat7:tomcat7 /var/lib/tomcat7/webapps/solr.war
+unzip -o /var/lib/tomcat7/webapps/solr.war -d /var/lib/tomcat7/webapps/solr/
+cp /tmp/solr-"$SOLR_VERSION"/example/lib/ext/* /var/lib/tomcat7/webapps/solr/WEB-INF/lib/
+chown -R tomcat7:tomcat7 /var/lib/tomcat7/webapps/solr*
 ln -s "$SOLR_HOME" /var/lib/tomcat7/solr
 
 # Restart Tomcat


### PR DESCRIPTION
**JIRA Ticket**: https://github.com/Islandora-Labs/islandora_vagrant_base_box/issues/28 (no JIRA just issue in queue)

# What does this Pull Request do?

Updates Fits to 1.1.0
Solr to 4.10.4
GSEARCH HEAD
gsearch_extensions 0.1.2

Some of the pathing has been updated to avoid having to change any files in basic-solr-config it should just work as is. No longer pulling pre-built GSEARCH configs from the York server since they wouldn't work after the updates. The ant process will now run when box is cut. 

# What's new?
Updated Fits, Solr, Gsearch, and Gsearch extensions. Also added log4j that will log gsearch errors to /usr/local/fedora/server/logs/fedoragsearch.log.

# How should this be tested?

Clone my repo. Bring up islandora_vagrant_base_box then halt and package. After packaging add the package.box

vagrant box add testbox package.box 

Then update config.vm.box = "testbox" in the islandora_vagrant Vagrantfile.

Then in islandora_vagrant

vagrant up

Try to ingest, modify and delete objects. Ensure that Solr is updating as expected. 

# Additional Notes:
Note: Drupal, PHP and other binaries will be updated when the new basebox is cut. Tomcat is currently installing from latest from Ubuntu repositories. Pulling it out to install from source is going to be a lot more work than first anticipated and should be handled under a seperate issue/PR if we feel that it is still necessary. Gsearch has been updated so it should be compatible with latest Tomcat when update takes place.


# Interested parties
@DonRichards
@Natkeeran
