### PR TITLE
Ghostscript Update

### DIFF
--- a/configs/variables
+++ b/configs/variables
@@ -12,6 +12,8 @@ FEDORA_HOME="/usr/local/fedora"
 
 FFMPEG_VERSION=1.1.4
 
+GHOSTSCRIPT_VERSION=9.23
+
 FITS_HOME="/usr/local/fits"
 FITS_VERSION=1.1.1
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -61,6 +61,16 @@ MAN_FILES=$(wget -qO- "http://sourceforge.net/projects/zsh/files/zsh/5.0.2/zsh-5
   | tar xvz -C /usr/share/man/man1/ --wildcards "zsh-5.0.2/Doc/*.1" --strip-components=2)
 for MAN_FILE in $MAN_FILES; do gzip /usr/share/man/man1/"${MAN_FILE##*/}"; done
 
+# Fix for https://github.com/Islandora-Labs/islandora_vagrant/issues/127 
+# GhostScript version (9.10) fails to extract PDF pages on RGB format
+cd /opt
+wget https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs923/ghostscript-9.23.tar.gz
+tar xvzf ghostscript-9.23.tar.gz
+cd ghostscript-9.23
+./configure
+make
+checkinstall --pkgname=ghostscript --pkgversion="9.23-dgi" --backup=no --deldoc=yes --fstrans=no --default
+
 # More helpful packages
 apt-get -y install htop tree zsh #fish
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -63,13 +63,18 @@ for MAN_FILE in $MAN_FILES; do gzip /usr/share/man/man1/"${MAN_FILE##*/}"; done
 
 # Fix for https://github.com/Islandora-Labs/islandora_vagrant/issues/127 
 # GhostScript version (9.10) fails to extract PDF pages on RGB format
-cd /opt
-wget https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs923/ghostscript-9.23.tar.gz
-tar xvzf ghostscript-9.23.tar.gz
-cd ghostscript-9.23
+if [ ! -f "$DOWNLOAD_DIR/ghostscript-$GHOSTSCRIPT_VERSION.tar.gz" ]; then
+  echo "Downloading Ghostscript"
+  wget -q -O "$DOWNLOAD_DIR/ghostscript-$GHOSTSCRIPT_VERSION.tar.gz" "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${GHOSTSCRIPT_VERSION//.}/ghostscript-$GHOSTSCRIPT_VERSION.tar.gz"
+fi
+cd /tmp || exit
+cp "$DOWNLOAD_DIR/ghostscript-$GHOSTSCRIPT_VERSION.tar.gz" /tmp
+tar xvzf ghostscript-$GHOSTSCRIPT_VERSION.tar.gz
+cd ghostscript-$GHOSTSCRIPT_VERSION || exit
 ./configure
 make
-checkinstall --pkgname=ghostscript --pkgversion="9.23-dgi" --backup=no --deldoc=yes --fstrans=no --default
+checkinstall --pkgname=ghostscript --pkgversion="$GHOSTSCRIPT_VERSION-fix" --backup=no --deldoc=yes --fstrans=no --default
+ln -s /usr/local/bin/gs /usr/bin/gs
 
 # More helpful packages
 apt-get -y install htop tree zsh #fish

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -69,8 +69,8 @@ if [ ! -f "$DOWNLOAD_DIR/ghostscript-$GHOSTSCRIPT_VERSION.tar.gz" ]; then
 fi
 cd /tmp || exit
 cp "$DOWNLOAD_DIR/ghostscript-$GHOSTSCRIPT_VERSION.tar.gz" /tmp
-tar xvzf ghostscript-$GHOSTSCRIPT_VERSION.tar.gz
-cd ghostscript-$GHOSTSCRIPT_VERSION || exit
+tar xvzf "ghostscript-$GHOSTSCRIPT_VERSION.tar.gz"
+cd "ghostscript-$GHOSTSCRIPT_VERSION" || exit
 ./configure
 make && make install
 ln -s /usr/local/bin/gs /usr/bin/gs

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -72,9 +72,9 @@ cp "$DOWNLOAD_DIR/ghostscript-$GHOSTSCRIPT_VERSION.tar.gz" /tmp
 tar xvzf ghostscript-$GHOSTSCRIPT_VERSION.tar.gz
 cd ghostscript-$GHOSTSCRIPT_VERSION || exit
 ./configure
-make
-checkinstall --pkgname=ghostscript --pkgversion="$GHOSTSCRIPT_VERSION-fix" --backup=no --deldoc=yes --fstrans=no --default
+make && make install
 ln -s /usr/local/bin/gs /usr/bin/gs
+ldconfig
 
 # More helpful packages
 apt-get -y install htop tree zsh #fish


### PR DESCRIPTION
**JIRA Ticket**: 
https://jira.duraspace.org/browse/ISLANDORA-2035

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
https://github.com/Islandora/islandora_paged_content/commit/723004bb732d171ae7ad49f994878cc454641629
https://github.com/Islandora/islandora_paged_content/pull/137
Issue link https://github.com/Islandora-Labs/islandora_vagrant/issues/127

# What does this Pull Request do?

Updates Ghostscript to latest version 9.23 which should allow for compression. 

# What's new?
Updated Ghostscript version to the latest. 

# How should this be tested?
vagrant up
gs -v
Should show Ghostscript version 9.23. 
If it shows any other version or the gs -v command fails to run then the test should be considered failed. 

The box should be re-exported to ensure it still works with latest Islandora. 

As per Islandora-Labs/islandora_vagrant#127

> Ingest 2 newspapers (ideally multiple pages)
> Using a PDF
> 1st newspaper PDF should use the PAGE IMAGE SETTINGS at the upload page of 48-bit RGB, 150 DPI or 300 DPI with Extract text from the PDF
> 2nd newspaper PDF should use the PAGE IMAGE SETTINGS at the upload page of 32-bit CMYK, 300 DPI with Extract text from the PDF
> Check if derivatives were properly generated

# Additional Notes:
Completely optional PR we might want to think about sticking with 9.10 just for legacy reasons since it is still being maintained for security patches by Ubuntu.

Either way, we should be able to close out Issue link https://github.com/Islandora-Labs/islandora_vagrant/issues/127


# Interested parties
@DonRichards @Islandora-Labs/committers 
