### PR TITLE
Adds ffmpeg2theora installation to ffmpeg.sh

### DIFF
--- a/scripts/ffmpeg.sh
+++ b/scripts/ffmpeg.sh
@@ -29,3 +29,6 @@ tar -xzvf ffmpeg-"$FFMPEG_VERSION".tar.gz
 
 # Compile FFmpeg
 cd ffmpeg-"$FFMPEG_VERSION" && ./configure --enable-gpl --enable-version3 --enable-nonfree --enable-postproc --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libdc1394 --enable-libfaac --enable-libgsm --enable-libmp3lame --enable-libopenjpeg --enable-libschroedinger --enable-libspeex --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libxvid && make && make install && ldconfig
+
+# Install ffmpeg2theora
+apt-get -y install ffmpeg2theora


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2236

# What does this Pull Request do?
Adds `ffmpeg2theora` to the install.

# What's new?
`ffmpeg2theora` now exists at `/usr/bin/ffmpeg2theora`.

# How should this be tested?
Build the VM and run `which ffmpeg2theora`, result should be `/usr/bin/ffmpeg2theora`.

# Additional Notes:
This new VM will have to be exported to atlas before it can be tested as a solution for https://jira.duraspace.org/browse/ISLANDORA-2236. 

# Interested parties
@Islandora-Labs/committers @DonRichards @jonathangreen 
