### PR TITLE
Adding `config.ssh.insert_key = false`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.vmx["numvcpus"] = "2"
   end
 
+  config.ssh.insert_key = false
+  
   shared_dir = "/vagrant"
 
   config.vm.provision :shell, inline: "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile", :privileged =>false


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2329

# What does this Pull Request do?

Adds `config.ssh.insert_key = false` to the Vagrantfile.  This way it's already there the next time we want to upload a new base box and we don't have to go through https://github.com/Islandora-Labs/islandora_vagrant/pull/154 all over again.

# Interested parties
@Islandora-Labs/committers @DonRichards @br2490 @bryjbrown @DiegoPino 
