### PR TITLE
Enable Cantaloupe admin endpoint and add password

### DIFF
--- a/configs/cantaloupe.properties
+++ b/configs/cantaloupe.properties
@@ -100,9 +100,9 @@ endpoint.iiif.min_tile_size = 1024
 endpoint.iiif.2.restrict_to_sizes = false
 
 # Enables the Control Panel, at /admin.
-endpoint.admin.enabled = false
+endpoint.admin.enabled = true
 endpoint.admin.username = admin
-endpoint.admin.secret =
+endpoint.admin.secret = admin
 
 # Enables the administrative HTTP API. (See the user manual.)
 endpoint.api.enabled = false


### PR DESCRIPTION
JIRA Ticket: N/A

## What does this Pull Request do?
Per https://github.com/Islandora-Labs/islandora_vagrant/pull/159 this:
Enables the Cantaloupe admin endpoint and adds a password in the same format as other vagrant logins (where user===pass).

## What's new?
cantaloupe.properties updated for reason(s) above.

## How should this be tested?
Rebuild basebox and Islandora Vagrant
Visit http://localhost:8080/cantaloupe/admin login with admin:admin (uers:pass)

## Additional Notes:
@see https://github.com/Islandora-Labs/islandora_vagrant/pull/159

## Interested parties
@DonRichards, @Islandora-Labs/committers