### PR TITLE
Reusable workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   stale:
-    uses: Islandora-Labs/.github/blob/main/.github/workflows/stale.yaml@main
+    uses: Islandora-Labs/.github/.github/workflows/stale.yaml@main
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: 'Close stale issues and PRs'
+name: 'Manage stale issues and PRs'
 on:
   workflow_dispatch:
   schedule:
@@ -6,21 +6,5 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v9
-        with:
-          days-before-issue-stale: 90
-          days-before-issue-close: 14
-          stale-issue-message: 'This issue is being marked as stale from inactivity and will be automatically closed in 2 weeks unless further action is taken. If this issue is still relevant please comment. Please also consider attending the weekly Tech Call to discuss the issue'
-          days-before-pr-stale: 90 
-          days-before-pr-close: 14
-          stale-pr-message: 'This PR is being marked as stale from inactivity and will be automatically closed in 90 days unless further action is taken. If this PR is still relevant please comment. Please also consider attending the weekly Tech Call to discuss the PR'
-          exempt-issue-labels: 'feature request'
-      - uses: actions/stale@v9
-        with:
-          days-before-stale: 1
-          days-before-close: 14
-          stale-issue-message: 'This feture request issue is being marked as stale from inactivity and will be automatically closed in 2 weeks unless further action is taken. If this issue is still relevant please comment. Please also consider attending the weekly Tech Call to discuss the issue'
-          stale-pr-message: 'This feature request PR is being marked as stale from inactivity and will be automatically closed in 90 days unless further action is taken. If this PR is still relevant please comment. Please also consider attending the weekly Tech Call to discuss the PR'
-          only-labels: 'feature request'
+    uses: Islandora-Labs/.github/blob/main/.github/workflows/stale.yaml@main
+    secrets: inherit


### PR DESCRIPTION
Update stale action to reference a re-usable workflow: https://github.com/Islandora-Labs/.github/blob/main/.github/workflows/stale.yaml

We can create a `.github` repo in each of Islandora's orgs

- https://github.com/Islandora-labs
- https://github.com/Islandora-devops
- https://github.com/Islandora

We then would need to create a `stale.yaml` file like this one in every repo within the org. But it's only a few lines of code.

This allows us to manage the stale bot parameters in a singular place, without relying on third-party GitHub Actions. GHA's official stale action has not accepted a PR to allow org-wide bots https://github.com/actions/stale/pull/1081